### PR TITLE
Updated .gitignore for NetBeans and Eclipse

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,24 @@ nbdist/
 .nb-gradle/
 
 # Eclipse
+.metadata
+bin/
+tmp/
+*.tmp
+*.bak
+*.swp
+*~.nib
+local.properties
+.settings/
+.loadpath
+.recommenders
+.recommenders/
+.project
+.classpath
+.factorypath
+*.launch
+.externalToolBuilders/
+.target
+.tern-project
+.springBeans
+.texlipse

--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,11 @@
 target/
 
 # Netbeans
+nbproject/private/
+build/
+nbbuild/
+dist/
+nbdist/
+.nb-gradle/
 
 # Eclipse


### PR DESCRIPTION
There is a gitignore repo on GitHub, so I copied the relevant lines for each from there.